### PR TITLE
Add support for multi-label images

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,9 @@ venv.bak/
 # PyCharm project settings
 .idea
 
+# VS Code settings
+.vscode/
+
 # Rope project settings
 .ropeproject
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 Volumetric binary mask segmentation accuracy metrics
 
 ## Scope
-A small package for assessing the accuracy of binary segmentations. There are lots of metrics that can be used to compare how close two segmentations are, here voxel overlap, surface and volume based metrics are all calculated at once and returned either as individual metrics, a dictionary or a Pandas DataFrame.
+A small package for assessing the accuracy of binary and multi-label segmentations. There are lots of metrics that can be used to compare how close two segmentations are, here voxel overlap, surface and volume based metrics are all calculated at once and returned either as individual metrics, a dictionary or a Pandas DataFrame.
 
 This package supports multi-label segmentation masks, in which case the metrics are calculated for each label and then averaged across labels to give a single score for each metric. The volume based metrics are summed across labels rather than averaged.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Volumetric binary mask segmentation accuracy metrics
 ## Scope
 A small package for assessing the accuracy of binary and multi-label segmentations. There are lots of metrics that can be used to compare how close two segmentations are, here voxel overlap, surface and volume based metrics are all calculated at once and returned either as individual metrics, a dictionary or a Pandas DataFrame.
 
-This package supports multi-label segmentation masks, in which case the metrics are calculated for each label and then averaged across labels to give a single score for each metric. The volume based metrics are summed across labels rather than averaged.
+This package supports multi-label segmentation masks, in which case the metrics are calculated for each label and then averaged across labels to give a single score for each metric. The volume based metrics are summed across labels rather than averaged. By default, a saftey limit of 10 labels is applied and an error is raised if more than 10 distinct labels are found (e.g. in image is input rather than a labeled mask). If your images have more than 10 labels, set `many_labels=True` when initialising the `SegmentationMetrics` object to bypass this check and allow all labels to be included in the metrics calculation.
 
 The surface based metrics in this package are calculated using code from [deepmind's surface-distance](https://github.com/deepmind/surface-distance) repository, however as this is not available as a PyPI package, the code has been included as a submodule here.
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ Volumetric binary mask segmentation accuracy metrics
 ## Scope
 A small package for assessing the accuracy of binary segmentations. There are lots of metrics that can be used to compare how close two segmentations are, here voxel overlap, surface and volume based metrics are all calculated at once and returned either as individual metrics, a dictionary or a Pandas DataFrame.
 
+This package supports multi-label segmentation masks, in which case the metrics are calculated for each label and then averaged across labels to give a single score for each metric. The volume based metrics are summed across labels rather than averaged.
+
 The surface based metrics in this package are calculated using code from [deepmind's surface-distance](https://github.com/deepmind/surface-distance) repository, however as this is not available as a PyPI package, the code has been included as a submodule here.
 
 ## Installation

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -110,7 +110,7 @@ class SegmentationMetrics:
             segmented). If true, metrics are calculated and averaged across all
             labels.
         """
-        if prediction.dtype == 'float' and truth.dtype == 'float':
+        if prediction.dtype == 'float' or truth.dtype == 'float':
             if prediction.max() <= 1 and truth.max() <= 1:
                 prediction = (prediction > 0.5).astype(int)
                 truth = (truth > 0.5).astype(int)
@@ -153,7 +153,7 @@ class SegmentationMetrics:
                         mean_surface_distance_vals.append(np.nan)
                     else:
                         mean_surface_distance_vals.append((np.nan, np.nan))
-                        
+
                     hausdorff_distance_vals.append(np.nan)
                 else:
                     self._surface_dist = sd.compute_surface_distances(self.prediction == label,

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -61,20 +61,58 @@ class SegmentationMetrics:
         self.prediction = prediction > 0.5
         self.truth = truth > 0.5
         self.zoom = zoom
-        self.dice = self._dice()
-        self.jaccard = self._jaccard()
-        self.sensitivity = self._sensitivity()
-        self.specificity = self._specificity()
-        self.precision = self._precision()
-        self.accuracy = self._accuracy()
-        self._surface_dist = sd.compute_surface_distances(self.prediction,
-                                                          self.truth,
-                                                          self.zoom)
-        self.mean_surface_distance = self._av_dist(symmetric)
-        self.hausdorff_distance = self._hausdorff_dist(percentile)
-        self.true_volume = self._true_volume()
-        self.predicted_volume = self._predicted_volume()
-        self.volume_difference = self._volume_difference()
+        self.labels = np.unique(self.truth[self.truth > 0])
+
+        if self.labels.size == 0:
+            self.dice = np.nan
+            self.jaccard = np.nan
+            self.sensitivity = np.nan
+            self.specificity = np.nan
+            self.precision = np.nan
+            self.accuracy = np.nan
+            self.mean_surface_distance = np.nan
+            self.hausdorff_distance = np.nan
+            self.true_volume = np.nan
+            self.predicted_volume = np.nan
+            self.volume_difference = np.nan
+        else:
+            dice_vals = [self._dice(label) for label in self.labels]
+            jaccard_vals = [self._jaccard(label) for label in self.labels]
+            sensitivity_vals = [self._sensitivity(label) for label in self.labels]
+            specificity_vals = [self._specificity(label) for label in self.labels]
+            precision_vals = [self._precision(label) for label in self.labels]
+            accuracy_vals = [self._accuracy(label) for label in self.labels]
+            mean_surface_distance_vals = []
+            hausdorff_distance_vals = []
+            for label in self.labels:
+                if np.sum(self.truth == label) == 0 or np.sum(self.prediction == label) == 0:
+                    # If there are no voxels of this label in either the truth or prediction, set surface distances to infinity
+                    mean_surface_distance_vals.append(np.nan)
+                    hausdorff_distance_vals.append(np.nan)
+                else:
+                    self._surface_dist = sd.compute_surface_distances(self.prediction == label,
+                                                                    self.truth == label,
+                                                                    self.zoom)
+                    mean_surface_distance_vals.append(self._av_dist(symmetric))
+                    hausdorff_distance_vals.append(self._hausdorff_dist(percentile))
+            
+            self.dice = np.mean(dice_vals)
+            self.jaccard = np.mean(jaccard_vals)
+            self.sensitivity = np.mean(sensitivity_vals)
+            self.specificity = np.mean(specificity_vals)
+            self.precision = np.mean(precision_vals)
+            self.accuracy = np.mean(accuracy_vals)
+            self.mean_surface_distance = np.mean(mean_surface_distance_vals, axis=0)
+            self.hausdorff_distance = np.mean(hausdorff_distance_vals)
+            self.true_volume = np.sum([self._true_volume(label) for label in self.labels])
+            self.predicted_volume = np.sum([self._predicted_volume(label) for label in self.labels])
+            if self.labels.size == 1:
+                self.volume_difference = self._volume_difference(self.labels[0])
+            else:
+                self.volume_difference = np.sum(np.abs([self._volume_difference(label) for label in self.labels]))
+            # self.true_volume = self._true_volume()
+            # self.predicted_volume = self._predicted_volume()
+            # self.volume_difference = self._volume_difference()
 
     def get_dict(self):
         """
@@ -117,34 +155,53 @@ class SegmentationMetrics:
         df = df[['Metric', 'Score']]
         return df
 
-    def _dice(self):
-        return np.sum(self.prediction[self.truth == 1]) * 2.0 / \
-               (np.sum(self.prediction) + np.sum(self.truth))
+    def _dice(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tp + fp + fn == 0:
+            dice = 0.0
+        else:
+            dice = (2 * tp) / (2 * tp + fp + fn)
+        return dice
 
-    def _jaccard(self):
-        return np.sum(self.prediction[self.truth == 1]) / \
-               (np.sum(self.prediction[self.truth == 1]) +
-                np.sum(self.prediction != self.truth))
+    def _jaccard(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tp + fp + fn == 0:
+            jaccard = 0.0
+        else:
+            jaccard = tp / (tp + fp + fn)
+        return jaccard
 
-    def _sensitivity(self):
-        return np.sum(self.prediction[self.truth == 1]) / \
-               (np.sum(self.prediction[self.truth == 1]) +
-                np.sum((self.truth == 1) & (self.prediction == 0)))
+    def _sensitivity(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tp + fn == 0:
+            sensitivity = 0.0
+        else:
+            sensitivity = tp / (tp + fn)
+        return sensitivity
 
-    def _specificity(self):
-        return np.sum((self.truth == 0) & (self.prediction == 0)) / \
-               (np.sum((self.truth == 0) & (self.prediction == 0)) +
-                np.sum((self.truth == 0) & (self.prediction == 1)))
+    def _specificity(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tn + fp == 0:
+            specificity = 0.0
+        else:
+            specificity = tn / (tn + fp)
+        return specificity
 
-    def _precision(self):
-        return np.sum(self.prediction[self.truth == 1]) / \
-               (np.sum(self.prediction[self.truth == 1]) +
-                np.sum((self.truth == 0) & (self.prediction == 1)))
+    def _precision(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tp + fp == 0:
+            precision = 0.0
+        else:
+            precision = tp / (tp + fp)
+        return precision
 
-    def _accuracy(self):
-        return (np.sum(self.prediction[self.truth == 1]) +
-                np.sum((self.truth == 0) & (self.prediction == 0))) / \
-               self.truth.size
+    def _accuracy(self, label=1):
+        tp, fp, fn, tn = self._get_confusion_counts(label)
+        if tp + fp + fn + tn == 0:
+            accuracy = 0.0
+        else:
+            accuracy = (tp + tn) / (tp + fp + fn + tn)
+        return accuracy
 
     def _av_dist(self, symmetric=True):
         av_surf_dist = sd.compute_average_surface_distance(self._surface_dist)
@@ -157,11 +214,18 @@ class SegmentationMetrics:
     def _hausdorff_dist(self, percentile=95):
         return sd.compute_robust_hausdorff(self._surface_dist, percentile)
 
-    def _true_volume(self):
-        return np.sum(self.truth) * np.prod(self.zoom) / 1000
+    def _true_volume(self, label=1):
+        return np.sum(self.truth == label) * np.prod(self.zoom) / 1000
 
-    def _predicted_volume(self):
-        return np.sum(self.prediction) * np.prod(self.zoom) / 1000
+    def _predicted_volume(self, label=1):
+        return np.sum(self.prediction == label) * np.prod(self.zoom) / 1000
 
-    def _volume_difference(self):
-        return self.predicted_volume - self.true_volume
+    def _volume_difference(self, label=1):
+        return self._predicted_volume(label) - self._true_volume(label)
+    
+    def _get_confusion_counts(self, label):
+        tp = np.sum((self.prediction == label) & (self.truth == label))
+        fp = np.sum((self.prediction == label) & (self.truth != label))
+        fn = np.sum((self.prediction != label) & (self.truth == label))
+        tn = np.sum((self.prediction != label) & (self.truth != label))
+        return tp, fp, fn, tn

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -107,7 +107,7 @@ class SegmentationMetrics:
             If false, an error is raised if there are more than 10 labels in
             either the prediction or true mask. This is to prevent accidentally 
             running the metrics on a non-binary mask (e.g. the image that was 
-            segmented). If ture, metrics are calculated and averaged across all
+            segmented). If true, metrics are calculated and averaged across all
             labels.
         """
         if prediction.dtype == 'float' and truth.dtype == 'float':
@@ -147,8 +147,8 @@ class SegmentationMetrics:
             mean_surface_distance_vals = []
             hausdorff_distance_vals = []
             for label in self.labels:
-                if (np.sum(self.truth == label) == 0) | (np.sum(self.prediction == label) == 0):
-                    # If there are no voxels of this label in either the truth or prediction, set surface distances to infinity
+                if (np.sum(self.truth == label) == 0) or (np.sum(self.prediction == label) == 0):
+                    # If there are no voxels of this label in either the truth or prediction, set surface distances to nan as they are not defined
                     mean_surface_distance_vals.append(np.nan)
                     hausdorff_distance_vals.append(np.nan)
                 else:

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -149,7 +149,11 @@ class SegmentationMetrics:
             for label in self.labels:
                 if (np.sum(self.truth == label) == 0) or (np.sum(self.prediction == label) == 0):
                     # If there are no voxels of this label in either the truth or prediction, set surface distances to nan as they are not defined
-                    mean_surface_distance_vals.append(np.nan)
+                    if symmetric:
+                        mean_surface_distance_vals.append(np.nan)
+                    else:
+                        mean_surface_distance_vals.append((np.nan, np.nan))
+                        
                     hausdorff_distance_vals.append(np.nan)
                 else:
                     self._surface_dist = sd.compute_surface_distances(self.prediction == label,

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -10,29 +10,76 @@ class SegmentationMetrics:
     ----------
     dice : float
         Dice similarity score.
+        The dice score is a measure of the overlap between the predicted and true
+        masks. It is calculated as 2*TP / (2*TP + FP + FN).
+        If there are multiple labels, the dice score is the mean of the dice 
+        scores for each label.
     jaccard : float
         Jaccard similarity score.
+        The jaccard score is a measure of the overlap between the predicted and
+        true masks. It is calculated as TP / (TP + FP + FN).
+        If there are multiple labels, the jaccard score is the mean of the 
+        jaccard scores for each label.
     sensitivity : float
         Sensitivity/recall/true positive rate.
+        The sensitivity is the proportion of true positives that are correctly
+        identified. It is calculated as TP / (TP + FN).
+        If there are multiple labels, the sensitivity is the mean of the
+        sensitivities for each label.
     specificity : float
         Specificity/selectivity/true negative rate.
+        The specificity is the proportion of true negatives that are correctly
+        identified. It is calculated as TN / (TN + FP).
+        If there are multiple labels, the specificity is the mean of the
+        specificities for each label.
     precision : float
         Precision/positive predictive value.
+        The precision is the proportion of predicted positives that are true
+        positives. It is calculated as TP / (TP + FP).
+        If there are multiple labels, the precision is the mean of the
+        precisions for each label.
     accuracy : float
-        Accuracy.
+        Accuracy. 
+        The accuracy is the proportion of true results (both true positives and
+        true negatives) among the total number of cases examined. It is 
+        calculated as (TP + TN) / (TP + TN + FP + FN).
+        If there are multiple labels, the accuracy is the mean of the accuracies
+        for each label.
     mean_surface_distance : float or tuple
         The mean surface distance, defaults to symmetric.
+        The mean surface distance is the average distance between the surfaces 
+        of the predicted and true masks. If symmetric is True, the mean surface 
+        distance is the average of the mean surface distance from surface A to
+        surface B and the mean surface distance from surface B to surface A. If
+        symmetric is False, a tuple is returned with both mean surface 
+        distances.
+        If there are multiple labels, the mean surface distance is the mean of 
+        the mean surface distances for each label.
     hausdorff_distance : float
         The robust Hausdorff distance, defaults to 95th percentile.
+        The Hausdorff distance is the maximum distance of a set to the nearest
+        point in the other set. The robust Hausdorff distance is the distance at
+        a specified percentile of the distances from points on one surface to 
+        the other surface.
+        If there are multiple labels, the Hausdorff distance is the mean of the
+        Hausdorff distances for each label.
     true_volume : float
-        The volume of the true mask (in milliliters)
+        The volume of the true mask (in milliliters).
+        If there are multiple labels, the true volume is the sum of the true
+        volumes for each label.
     predicted_volume : float
         The volume of the predicted mask (in milliliters)
+        If there are multiple labels, the predicted volume is the sum of the
+        predicted volumes for each label.
     volume_difference : float
         The difference between the true and predicted volumes (in 
         milliliters). Positive values show the predicted volume is larger 
         than the true volume, negative values show the true volume is larger
         than the predicted volume.
+        If there are multiple labels, the volume difference is the sum of the 
+        absolute volume differences for each label, rather than the overall 
+        volume difference. This is to prevent positive and negative differences
+        cancelling each other out.
     """
     def __init__(self, prediction, truth, zoom, percentile=95, symmetric=True,
                  many_labels=False):
@@ -122,9 +169,6 @@ class SegmentationMetrics:
                 self.volume_difference = self._volume_difference(self.labels[0])
             else:
                 self.volume_difference = np.sum(np.abs([self._volume_difference(label) for label in self.labels]))
-            # self.true_volume = self._true_volume()
-            # self.predicted_volume = self._predicted_volume()
-            # self.volume_difference = self._volume_difference()
 
     def get_dict(self):
         """

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -34,18 +34,17 @@ class SegmentationMetrics:
         than the true volume, negative values show the true volume is larger
         than the predicted volume.
     """
-    def __init__(self, prediction, truth, zoom, percentile=95, symmetric=True):
+    def __init__(self, prediction, truth, zoom, percentile=95, symmetric=True,
+                 many_labels=False):
         """
         Initialises the SegmentationMetrics class instance.
 
         Parameters
         ----------
         prediction : np.ndarray
-            An array of bools or ints (0 and 1) representing the predicted
-            mask.
+            An array of bools or ints representing the predicted mask.
         truth : np.ndarray
-            An array of bools or ints (0 and 1) representing the ground truth
-            mask.
+            An array of bools or ints representing the ground truth mask.
         zoom : tuple
             The length of each voxel dimension in millimeters.
         percentile : int, default 95
@@ -57,11 +56,24 @@ class SegmentationMetrics:
             surface distance from surface A to surface B and the mean
             surface distance from surface B to surface A. If false, a tuple
             is returned with both mean surface distances.
+        many_labels : bool, default False
+            If false, an error is raised if there are more than 10 labels in
+            either the prediction or true mask. This is to prevent accidentally 
+            running the metrics on a non-binary mask (e.g. the image that was 
+            segmented). If ture, metrics are calculated and averaged across all
+            labels.
         """
-        self.prediction = prediction > 0.5
-        self.truth = truth > 0.5
+        self.prediction = prediction
+        self.truth = truth
         self.zoom = zoom
         self.labels = np.unique(self.truth[self.truth > 0])
+        prediction_labels = np.unique(self.prediction[self.prediction > 0])
+        if not many_labels:
+            if self.labels.size > 10 or prediction_labels.size > 10:
+                raise ValueError('More than 10 labels found in either the '
+                                 'prediction or truth. If you want to ' 
+                                 'calculate metrics for more than 10 labels, ' 
+                                 'set many_labels=True.')
 
         if self.labels.size == 0:
             self.dice = np.nan
@@ -85,7 +97,7 @@ class SegmentationMetrics:
             mean_surface_distance_vals = []
             hausdorff_distance_vals = []
             for label in self.labels:
-                if np.sum(self.truth == label) == 0 or np.sum(self.prediction == label) == 0:
+                if (np.sum(self.truth == label) == 0) | (np.sum(self.prediction == label) == 0):
                     # If there are no voxels of this label in either the truth or prediction, set surface distances to infinity
                     mean_surface_distance_vals.append(np.nan)
                     hausdorff_distance_vals.append(np.nan)

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -110,6 +110,10 @@ class SegmentationMetrics:
             segmented). If ture, metrics are calculated and averaged across all
             labels.
         """
+        if prediction.dtype == 'float' and truth.dtype == 'float':
+            if prediction.max() <= 1 and truth.max() <= 1:
+                prediction = (prediction > 0.5).astype(int)
+                truth = (truth > 0.5).astype(int)
         self.prediction = prediction
         self.truth = truth
         self.zoom = zoom

--- a/segmentationmetrics/metrics.py
+++ b/segmentationmetrics/metrics.py
@@ -113,14 +113,13 @@ class SegmentationMetrics:
         self.prediction = prediction
         self.truth = truth
         self.zoom = zoom
-        self.labels = np.unique(self.truth[self.truth > 0])
-        prediction_labels = np.unique(self.prediction[self.prediction > 0])
+        self.labels = np.unique(np.concatenate((prediction[prediction > 0], truth[truth > 0])))
         if not many_labels:
-            if self.labels.size > 10 or prediction_labels.size > 10:
-                raise ValueError('More than 10 labels found in either the '
-                                 'prediction or truth. If you want to ' 
-                                 'calculate metrics for more than 10 labels, ' 
-                                 'set many_labels=True.')
+            if self.labels.size > 10:
+                raise ValueError('More than 10 labels found in prediction '
+                                 'and/or truth. If you want to calculate '
+                                 'metrics for more than 10 labels, set '
+                                 'many_labels=True.')
 
         if self.labels.size == 0:
             self.dice = np.nan

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -7,6 +7,7 @@ from skimage.morphology import ball
 
 
 def assert_dict_approx(actual, expected, rel=1e-20, abs=1e-4):
+    assert set(actual.keys()) == set(expected.keys())
     for k, v in expected.items():
         assert k in actual
         a = actual[k]
@@ -20,7 +21,7 @@ class TestSegmentationMetrics:
     # Generate three spherical masks, two that are similar and one that
     # doesn't overlap at all
     img_shape = (256, 256, 256)
-    canvas = np.zeros(img_shape)
+    canvas = np.zeros(img_shape, dtype=np.int8)
 
     # Base sphere
     centre_a = (128, 128, 128)
@@ -111,6 +112,24 @@ class TestSegmentationMetrics:
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
         # Verify dataframe is returned
         assert type(sm.get_df()) == pd.DataFrame
+
+    def test_float_case(self):
+        # One image is a float array, checks these get thresholded.
+        img_b_float = self.img_b.astype(float)
+        img_b_float[img_b_float > 0.5] = 0.9
+        sm = SegmentationMetrics(self.img_a, img_b_float, (1, 1, 1))
+        expected = {'accuracy': 0.9810,
+                'dice': 0.9216,
+                'hausdorff_distance': 8.6023,
+                'jaccard': 0.8546,
+                'mean_surface_distance': 3.6676,
+                'precision': 0.8719,
+                'predicted_volume': 2143.641,
+                'sensitivity': 0.9773,
+                'specificity': 0.9815,
+                'true_volume': 1912.319,
+                'volume_difference': 231.3220}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
     def test_options(self):
         # Confirm changing Hausdorff percentile and surface distance

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -185,7 +185,6 @@ class TestSegmentationMetrics:
                     'specificity': 0.0,
                     'true_volume': 14633.575,
                     'volume_difference': -12489.9340}
-        print(sm.get_dict())
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
     def test_no_labels(self):

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -81,6 +81,18 @@ class TestSegmentationMetrics:
           centre_e[1] + ball_e.shape[1] // 2 + 1,
           centre_e[2] - ball_e.shape[2] // 2:
           centre_e[2] + ball_e.shape[2] // 2 + 1] += ball_e
+    
+    # Add a second label to img_a that doesn't overlap with the first label in img_a
+    centre_f = (10, 10, 10)
+    radius_f = 4
+    ball_f = ball(radius_f)
+    img_f = img_a.copy()
+    img_f[centre_f[0] - ball_f.shape[0] // 2:
+          centre_f[0] + ball_f.shape[0] // 2 + 1,
+          centre_f[1] - ball_f.shape[1] // 2:
+          centre_f[1] + ball_f.shape[1] // 2 + 1,
+          centre_f[2] - ball_f.shape[2] // 2:
+          centre_f[2] + ball_f.shape[2] // 2 + 1] += (ball_f * 2)
 
     def test_basic_case(self):
         # Overlapping spheres, isotropic voxels
@@ -209,6 +221,22 @@ class TestSegmentationMetrics:
                 'true_volume': 1912.319,
                 'volume_difference': 231.3220}
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
+    def test_multilabel_labels_dont_overlap(self):
+        # Test where label 1 doesn't overlap with label 2 in the ground truth
+        sm = SegmentationMetrics(self.img_f, self.img_e, (1, 1, 1))
+        expected = {'accuracy': 0.9866,
+                'dice': 0.4520,
+                'hausdorff_distance': 147.6504,
+                'jaccard': 0.4124,
+                'mean_surface_distance': 124.8019,
+                'precision': 0.4207,
+                'predicted_volume': 2143.898,
+                'sensitivity': 0.4883,
+                'specificity': 0.9886,
+                'true_volume': 1912.319,
+                'volume_difference': 361.5990}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)    
         
     def test_multilabel_missing_label(self):
         # Test with multiple labels, but one label missing from the prediction

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -6,6 +6,16 @@ from segmentationmetrics import SegmentationMetrics
 from skimage.morphology import ball
 
 
+def assert_dict_approx(actual, expected, rel=1e-20, abs=1e-4):
+    for k, v in expected.items():
+        assert k in actual
+        a = actual[k]
+        if np.isnan(v):
+            assert np.isnan(a)
+        else:
+            assert a == pytest.approx(v, rel=rel, abs=abs)
+
+
 class TestSegmentationMetrics:
     # Generate three spherical masks, two that are similar and one that
     # doesn't overlap at all
@@ -47,22 +57,46 @@ class TestSegmentationMetrics:
           centre_c[1] + ball_c.shape[1] // 2 + 1,
           centre_c[2] - ball_c.shape[2] // 2:
           centre_c[2] + ball_c.shape[2] // 2 + 1] = ball_c
+    
+    # Add a second label to img_a
+    centre_d = (140, 140, 140)
+    radius_d = 30
+    ball_d = ball(radius_d)
+    img_d = img_a.copy()
+    img_d[centre_d[0] - ball_d.shape[0] // 2:
+          centre_d[0] + ball_d.shape[0] // 2 + 1,
+          centre_d[1] - ball_d.shape[1] // 2:
+          centre_d[1] + ball_d.shape[1] // 2 + 1,
+          centre_d[2] - ball_d.shape[2] // 2:
+          centre_d[2] + ball_d.shape[2] // 2 + 1] += ball_d
+    
+    # Add a second label to img_b
+    centre_e = (160, 160, 160)
+    radius_e = 25
+    ball_e = ball(radius_e)
+    img_e = img_b.copy()
+    img_e[centre_e[0] - ball_e.shape[0] // 2:
+          centre_e[0] + ball_e.shape[0] // 2 + 1,
+          centre_e[1] - ball_e.shape[1] // 2:
+          centre_e[1] + ball_e.shape[1] // 2 + 1,
+          centre_e[2] - ball_e.shape[2] // 2:
+          centre_e[2] + ball_e.shape[2] // 2 + 1] += ball_e
 
     def test_basic_case(self):
         # Overlapping spheres, isotropic voxels
         sm = SegmentationMetrics(self.img_a, self.img_b, (1, 1, 1))
-        assert sm.get_dict() == pytest.approx({'accuracy': 0.9810,
-                                               'dice': 0.9216,
-                                               'hausdorff_distance': 8.6023,
-                                               'jaccard': 0.8546,
-                                               'mean_surface_distance': 3.6676,
-                                               'precision': 0.8719,
-                                               'predicted_volume': 2143.641,
-                                               'sensitivity': 0.9773,
-                                               'specificity': 0.9815,
-                                               'true_volume': 1912.319,
-                                               'volume_difference': 231.3220},
-                                              rel=1e-20, abs=1e-4)
+        expected = {'accuracy': 0.9810,
+                'dice': 0.9216,
+                'hausdorff_distance': 8.6023,
+                'jaccard': 0.8546,
+                'mean_surface_distance': 3.6676,
+                'precision': 0.8719,
+                'predicted_volume': 2143.641,
+                'sensitivity': 0.9773,
+                'specificity': 0.9815,
+                'true_volume': 1912.319,
+                'volume_difference': 231.3220}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
         # Verify dataframe is returned
         assert type(sm.get_df()) == pd.DataFrame
 
@@ -79,49 +113,122 @@ class TestSegmentationMetrics:
         # Overlapping spheres, non-isotropic voxels
         sm = SegmentationMetrics(self.img_a[..., ::2], self.img_b[..., ::2],
                                  (1, 1, 2))
-        assert sm.get_dict() == pytest.approx({'accuracy': 0.9811,
-                                               'dice': 0.9218,
-                                               'hausdorff_distance': 8.4853,
-                                               'jaccard': 0.8549,
-                                               'mean_surface_distance': 3.5352,
-                                               'precision': 0.8724,
-                                               'predicted_volume': 2142.914,
-                                               'sensitivity': 0.9770,
-                                               'specificity': 0.9816,
-                                               'true_volume': 1913.474,
-                                               'volume_difference': 229.4400},
-                                              rel=1e-20, abs=1e-4)
+        expected = {'accuracy': 0.9811,
+                'dice': 0.9218,
+                'hausdorff_distance': 8.4853,
+                'jaccard': 0.8549,
+                'mean_surface_distance': 3.5352,
+                'precision': 0.8724,
+                'predicted_volume': 2142.914,
+                'sensitivity': 0.9770,
+                'specificity': 0.9816,
+                'true_volume': 1913.474,
+                'volume_difference': 229.4400}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
     def test_2d(self):
         sm = SegmentationMetrics(self.img_a[..., 128], self.img_b[..., 128],
                                  (1, 1))
-        assert sm.get_dict() == pytest.approx({'accuracy': 0.9688,
-                                               'dice': 0.9470,
-                                               'hausdorff_distance': 8.4853,
-                                               'jaccard': 0.8993,
-                                               'mean_surface_distance': 3.8745,
-                                               'precision': 0.9110,
-                                               'predicted_volume': 20.081,
-                                               'sensitivity': 0.9860,
-                                               'specificity': 0.9619,
-                                               'true_volume': 18.553,
-                                               'volume_difference': 1.5280},
-                                              rel=1e-20, abs=1e-4)
+        expected = {'accuracy': 0.9688,
+                'dice': 0.9470,
+                'hausdorff_distance': 8.4853,
+                'jaccard': 0.8993,
+                'mean_surface_distance': 3.8745,
+                'precision': 0.9110,
+                'predicted_volume': 20.081,
+                'sensitivity': 0.9860,
+                'specificity': 0.9619,
+                'true_volume': 18.553,
+                'volume_difference': 1.5280}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
     def test_no_overlap(self):
         # Non-overlapping spheres
         sm = SegmentationMetrics(self.img_a, self.img_c, (1, 1, 1))
-        assert sm.get_dict() == pytest.approx({'accuracy': 0.8563,
-                                               'dice': 0.0,
-                                               'hausdorff_distance': 169.2661,
-                                               'jaccard': 0.0,
-                                               'mean_surface_distance': 84.2791,
-                                               'precision': 0.0,
-                                               'predicted_volume': 2143.641,
-                                               'sensitivity': 0.0,
-                                               'specificity': 0.8702,
-                                               'true_volume': 267.761,
-                                               'volume_difference': 1875.88},
-                                              rel=1e-20, abs=1e-4)
-        assert type(sm.get_df()) == pd.DataFrame
+        expected = {'accuracy': 0.8563,
+                'dice': 0.0,
+                'hausdorff_distance': 169.2661,
+                'jaccard': 0.0,
+                'mean_surface_distance': 84.2791,
+                'precision': 0.0,
+                'predicted_volume': 2143.641,
+                'sensitivity': 0.0,
+                'specificity': 0.8702,
+                'true_volume': 267.761,
+                'volume_difference': 1875.88}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
+    def test_all_wrong(self):
+        # Test with all voxels misclassified
+        sm = SegmentationMetrics(self.img_a, np.logical_not(self.img_a),
+                                 (1, 1, 1))
+        expected = {'accuracy': 0.0,
+                    'dice': 0.0,
+                    'hausdorff_distance': 116.6919,
+                    'jaccard': 0.0,
+                    'mean_surface_distance': 34.0172,
+                    'precision': 0.0,
+                    'predicted_volume': 2143.641,
+                    'sensitivity': 0.0,
+                    'specificity': 0.0,
+                    'true_volume': 14633.575,
+                    'volume_difference': -12489.9340}
+        print(sm.get_dict())
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
+    def test_no_labels(self):
+        # Test with no labels in either prediction or truth
+        sm = SegmentationMetrics(np.zeros(self.img_shape, dtype=bool),
+                                 np.zeros(self.img_shape, dtype=bool),
+                                 (1, 1, 1))
+        expected = {'accuracy': np.nan,
+                    'dice': np.nan,
+                    'hausdorff_distance': np.nan,
+                    'jaccard': np.nan,
+                    'mean_surface_distance': np.nan,
+                    'precision': np.nan,
+                    'predicted_volume': np.nan,
+                    'sensitivity': np.nan,
+                    'specificity': np.nan,
+                    'true_volume': np.nan,
+                    'volume_difference': np.nan}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
+    def test_multilabel_basic(self):
+        # Test with multiple labels
+        sm = SegmentationMetrics(self.img_d, self.img_e, (1, 1, 1))
+        expected = {'accuracy': 0.9817,
+                'dice': 0.5264,
+                'hausdorff_distance': 30.8881,
+                'jaccard': 0.4401,
+                'mean_surface_distance': 10.9338,
+                'precision': 0.4883,
+                'predicted_volume': 2143.641,
+                'sensitivity': 0.5799,
+                'specificity': 0.9862,
+                'true_volume': 1912.319,
+                'volume_difference': 231.3220}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+        
+    def test_multilabel_missing_label(self):
+        # Test with multiple labels, but one label missing from the prediction
+        sm = SegmentationMetrics(self.img_a, self.img_e, (1, 1, 1))
+        expected = {'accuracy': 0.9866,
+                    'dice': 0.4520,
+                    'hausdorff_distance': np.nan,
+                    'jaccard': 0.4124,
+                    'mean_surface_distance': np.nan,
+                    'precision': 0.4207,
+                    'predicted_volume': 2143.641,
+                    'sensitivity': 0.4883,
+                    'specificity': 0.9886,
+                    'true_volume': 1912.319,
+                    'volume_difference': 361.8560}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
+    def test_many_labels_error(self):
+        # Test that error is raised if more than 10 labels are present and
+        # many_labels=False
+        img = np.arange(12).reshape((2, 2, 3))
+        with pytest.raises(ValueError, match='More than 10 labels found'):
+            SegmentationMetrics(img, img, (1, 1, 1), many_labels=False)

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -226,6 +226,26 @@ class TestSegmentationMetrics:
                     'volume_difference': 361.8560}
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
+    def test_non_consecutive_labels(self):
+        # Test with non-consecutive labels
+        img_d = self.img_d.copy()
+        img_d[img_d == 2] = 3
+        img_e = self.img_e.copy()
+        img_e[img_e == 2] = 3
+        sm = SegmentationMetrics(img_d, img_e, (1, 1, 1))
+        expected = {'accuracy': 0.9817,
+                'dice': 0.5264,
+                'hausdorff_distance': 30.8881,
+                'jaccard': 0.4401,
+                'mean_surface_distance': 10.9338,
+                'precision': 0.4883,
+                'predicted_volume': 2143.641,
+                'sensitivity': 0.5799,
+                'specificity': 0.9862,
+                'true_volume': 1912.319,
+                'volume_difference': 231.3220}
+        assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
     def test_many_labels_error(self):
         # Test that error is raised if more than 10 labels are present and
         # many_labels=False

--- a/segmentationmetrics/tests/test_metrics.py
+++ b/segmentationmetrics/tests/test_metrics.py
@@ -221,6 +221,14 @@ class TestSegmentationMetrics:
                 'volume_difference': 231.3220}
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
 
+    def test_multilabel_with_options(self):
+        # Test with multiple labels and non-default options
+        sm = SegmentationMetrics(self.img_d, self.img_e, (1, 1, 1), 
+                                 symmetric=False, percentile=99)
+        assert np.isclose(sm.hausdorff_distance, 37.4730, rtol=1e-20, atol=1e-4)
+        assert np.isclose(sm.mean_surface_distance, (12.9019,  8.9657),
+                          rtol=1e-20, atol=1e-4).all()
+
     def test_multilabel_labels_dont_overlap(self):
         # Test where label 1 doesn't overlap with label 2 in the ground truth
         sm = SegmentationMetrics(self.img_f, self.img_e, (1, 1, 1))
@@ -252,6 +260,16 @@ class TestSegmentationMetrics:
                     'true_volume': 1912.319,
                     'volume_difference': 361.8560}
         assert_dict_approx(sm.get_dict(), expected, rel=1e-20, abs=1e-4)
+
+    def test_multilabel_with_options_missing_label(self):
+        # Test with multiple labels, non-default options and one label missing 
+        # from the prediction
+        sm = SegmentationMetrics(self.img_a, self.img_e, (1, 1, 1), 
+                                 symmetric=False, percentile=99)
+        assert np.isnan(sm.hausdorff_distance)
+        msd_arr = np.array(sm.mean_surface_distance)
+        assert msd_arr.shape == (2,)  
+        assert np.all(np.isnan(msd_arr)) 
 
     def test_non_consecutive_labels(self):
         # Test with non-consecutive labels


### PR DESCRIPTION
In some cases segmentations output multiple labels e.g. grey matter and white matter and background in the brain. This feature calculates each metric for each label then takes the average.